### PR TITLE
Fix "Can't open WebSocket while closing" errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ HarmonyPlatform.prototype = {
           that.account_id = body.data.accountId;
 
           wsUrl = `ws://${that.hubIP}:${DEFAULT_HUB_PORT}/?domain=${that.domain}&hubId=${that.remote_id}`;
-    
+
           that.wsp = new WebSocketAsPromised(wsUrl, {
             createWebSocket: url => new W3CWebSocket(url),
             packMessage: data => JSON.stringify(data),
@@ -91,8 +91,6 @@ HarmonyPlatform.prototype = {
           }
 
           that.wsp.onUnpackedMessage.addListener((data) => {
-
-            that.wsp.close();
             that.wsp.removeAllListeners();
             var foundAccessories = [];
             var services = [];
@@ -156,48 +154,41 @@ HarmonyPlatform.prototype = {
       }
     }
 
-    var that = this;
-    that.wsp.onUnpackedMessage.addListener((data) => {
-      that.wsp.close();
-      that.wsp.removeAllListeners();
+    this.wsp.onUnpackedMessage.addListener((data) => {
+      this.wsp.removeAllListeners();
 
-      
       for (var s = 0; s < homebridgeAccessory.services.length; s++) {
         var service = homebridgeAccessory.services[s];
         var characteristic = service.controlService.getCharacteristic(service.characteristics[0]);
 
         if (service.controlService.id == params.activityId)
         {
-          that.log(service.controlService.displayName + " launched");
+          this.log(service.controlService.displayName + " launched");
         }
-        
-        if (service.controlService.id !=-1 && service.controlService.id != params.activityId && characteristic.value) 
+
+        if (service.controlService.id !=-1 && service.controlService.id != params.activityId && characteristic.value)
         {
-          that.log("Switching off " + service.controlService.displayName);
+          this.log("Switching off " + service.controlService.displayName);
           characteristic.updateValue(false,undefined,'fromSetValue');
         }
 
         if (service.controlService.id == -1 && params.activityId == -1)
         {
-          that.log("Everything is off, turning on off Activity " + service.controlService.displayName);
+          this.log("Everything is off, turning on off Activity " + service.controlService.displayName);
           characteristic.updateValue(true,undefined,'fromSetValue');
         }
 
         if (service.controlService.id == -1 && params.activityId != -1 && characteristic.value)
         {
-          that.log("New activity on , turning off off Activity " + service.controlService.displayName);
+          this.log("New activity on , turning off off Activity " + service.controlService.displayName);
           characteristic.updateValue(false,undefined,'fromSetValue');
         }
-
-
       }
-
-
     });
 
-    that.wsp.open()
-      .then(() => that.wsp.sendPacked(payload))
-      .catch((e) => { that.log("Error :" + e); });
+    this.wsp.open()
+      .then(() => this.wsp.sendPacked(payload))
+      .catch((e) => { this.log("Error :" + e); });
 
   },
   getInformationService: function (homebridgeAccessory) {
@@ -249,11 +240,9 @@ HarmonyPlatform.prototype = {
         }
 
 
-        var that = this;
-        that.wsp.onUnpackedMessage.addListener((data) => {
-          that.wsp.close();
-          that.wsp.removeAllListeners();
-          that.log("Got status for " + service.controlService.displayName);
+        this.wsp.onUnpackedMessage.addListener((data) => {
+          this.wsp.removeAllListeners();
+          this.log("Got status for " + service.controlService.displayName);
           if (data.data.result == service.controlService.id) {
             callback(undefined, true);
           }
@@ -262,8 +251,8 @@ HarmonyPlatform.prototype = {
           }
         });
 
-        that.wsp.open()
-          .then(() => that.wsp.sendPacked(payload))
+        this.wsp.open()
+          .then(() => this.wsp.sendPacked(payload))
           .catch((e) => { console.error(e); callback(undefined, false); });
 
       }.bind(this));
@@ -291,4 +280,3 @@ HarmonyPlatform.prototype = {
 function HarmonyAccessory(services) {
   this.services = services;
 }
-

--- a/index.js
+++ b/index.js
@@ -243,12 +243,8 @@ HarmonyPlatform.prototype = {
         this.wsp.onUnpackedMessage.addListener((data) => {
           this.wsp.removeAllListeners();
           this.log("Got status for " + service.controlService.displayName);
-          if (data.data.result == service.controlService.id) {
-            callback(undefined, true);
-          }
-          else {
-            callback(undefined, false);
-          }
+
+          callback(null, data.data.result == service.controlService.id);
         });
 
         this.wsp.open()


### PR DESCRIPTION
First off, I'd like to give a huge thank you for this plugin! It's been working great for the most part. 

Occasionally, I've been encountering these errors:

```
Error: Can't open WebSocket while closing.
    at e.value (/homebridge-harmony/node_modules/websocket-as-promised/dist/index.js:2:13242)
    at HarmonyPlatform.<anonymous> (/homebridge-harmony/index.js:265:18)
    at Characteristic.On.emit (events.js:182:13)
    at Characteristic.On.Characteristic.getValue (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Characteristic.js:163:10)
    at Bridge.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:760:20)
    at Array.forEach (<anonymous>)
    at Bridge.Accessory._handleGetCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/Accessory.js:724:8)
    at HAPServer.emit (events.js:182:13)
    at HAPServer._handleCharacteristics (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:926:10)
    at HAPServer.<anonymous> (/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/HAPServer.js:209:39)

/usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/util/once.js:12
      throw new Error("This callback function has already been called by someone else; it can only be called one time.");
      ^

Error: This callback function has already been called by someone else; it can only be called one time.
    at /usr/local/lib/node_modules/homebridge/node_modules/hap-nodejs/lib/util/once.js:12:13
    at that.wsp.onUnpackedMessage.addListener (/homebridge-harmony/index.js:261:13)
    at Timeout._onTimeout (/homebridge-harmony/node_modules/websocket-as-promised/dist/index.js:2:4404)
    at ontimeout (timers.js:436:11)
    at tryOnTimeout (timers.js:300:5)
    at listOnTimeout (timers.js:263:5)
    at Timer.processTimers (timers.js:223:10)
```

As far as I can tell, this happens whenever HAP sends several requests to get the accessories' characteristics in quick succession. This causes the plugin to try and open websocket connections while existing connections are still being closed.

I verified that removing the `close()` calls fixes this issue and all functionality still behaves as expected. According to the [websocket-as-promised docs](https://github.com/vitalets/websocket-as-promised#WebSocketAsPromised+open), it's safe to call `open()` on existing connections.

Additional minor changes:
* Cleaned up the references of `that` where it's not needed, since arrow functions have access to `this` from the enclosing scope.
* Simplified callback if/else statement in `characteristic.on('get')`