### PR TITLE
Require Node v6+

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "homebridge": ">=0.2.0",
-    "node": ">=0.12.0"
+    "node": ">=6.0.0"
   },
   "keywords": [
     "homebridge-plugin",


### PR DESCRIPTION
Changes `package.json` so that the minimum supported version of Node.js is v6.0.0.

This is important because most packages (including current dependencies of this package like [request](https://github.com/request/request/blob/master/package.json#L21)) depend on [many of the language features](https://node.green/) that were introduced in v6.0.0.