### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Fields:
 - `publishGeneralVolumeSlider` publish a volume slider, stateless, that will send a volume commands to current activity. Approximativley, it will send an Up / Down Volume command each 5%. It can be combined with `numberOfCommandsSentForVolumeControl` option to multiply the number of up / down commands sent.
 - `publishGeneralVolumeSwitches` publish switches, stateless, for volume up / down on TV Accessory. It can be combined with `numberOfCommandsSentForVolumeControl` option to multiply the number of up / down commands sent.
 - `linkVolumeControlToTV`links mute / volume switch to TV accessory if present
-- `remoteOverrideCommandsList` option to ovverride default commands mapping in TV Platform Mode. See below for format.
+- `remoteOverrideCommandsList` option to override default commands mapping in TV Platform Mode. See below for format.
 - `activitiesToPublishAsInputForTVMode` array of Activities you want to expose as inputs (all by default)
 - `numberOfCommandsSentForVolumeControl` option to set the number of commands to send for each volum (up or down) press. Defaults to 1
 - `showCommandsAtStartup` show commands and device losts at startup (defaults to false)
@@ -221,7 +221,7 @@ See [Logitech Harmony Sequence Configuration](https://support.myharmony.com/en-u
 
 - You should put the name of the activity as it is named in harmony app,
 - Then an Array CommandsList with :
-  - the name of the command you want to ovverride
+  - the name of the command you want to override
   - the commands like in devicesToPublishAsAccessoriesSwitch (with the name of the device first)
 
 ```json

--- a/config.schema.json
+++ b/config.schema.json
@@ -651,7 +651,7 @@
             },
             {
               "type": "help",
-              "helpvalue": "<h6>Option to ovverride default commands mapping in TV Platform Mode</h6><em class='primary-text'>Command format : [Device Name];[Command Name].</em>"
+              "helpvalue": "<h6>Option to override default commands mapping in TV Platform Mode</h6><em class='primary-text'>Command format : [Device Name];[Command Name].</em>"
             },
             {
               "nodescription": true,
@@ -1021,7 +1021,7 @@
                         },
                         {
                           "type": "help",
-                          "helpvalue": "<h6>Option to ovverride default commands mapping in TV Platform Mode</h6><em class='primary-text'>Command format : [Device Name];[Command Name].</em>"
+                          "helpvalue": "<h6>Option to override default commands mapping in TV Platform Mode</h6><em class='primary-text'>Command format : [Device Name];[Command Name].</em>"
                         },
                         {
                           "nodescription": true,

--- a/harmonyAsTVKeysTools.js
+++ b/harmonyAsTVKeysTools.js
@@ -129,7 +129,7 @@ module.exports = {
             '(' +
               platform.name +
               ')' +
-              'INFO - commands found for ovverride : ' +
+              'INFO - commands found for override : ' +
               platform._currentInputService.activityName +
               '-' +
               command +
@@ -141,7 +141,7 @@ module.exports = {
             '(' +
               platform.name +
               ')' +
-              'WARNING - Command not found for ovverride : ' +
+              'WARNING - Command not found for override : ' +
               platform._currentInputService.activityName +
               '-' +
               device +
@@ -158,7 +158,7 @@ module.exports = {
           '(' +
             platform.name +
             ')' +
-            'ERROR - No commands found for ovverride : ' +
+            'ERROR - No commands found for override : ' +
             platform._currentInputService.activityName +
             '-' +
             command


### PR DESCRIPTION
Fix typo “ovverride” → “override”