### PR TITLE
fix for issue #410. This fixes the 'TV showing as undefined'

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -52,8 +52,9 @@
         "type": "boolean"
       },
       "TVAccessory": {
-        "title": "TV accessory in homekit (Defaults to true if not set)",
-        "type": "boolean"
+        "title": "TV accessory in homekit",
+        "type": "boolean",
+        "default": true
       },
       "sortInput": {
         "title": "sort input list in TV accessory : 0-default,1:Alpha,2:activityOrder property of hub, 3:activitiesToPublishAsInputForTVMode order (defaults to 0).",
@@ -335,8 +336,9 @@
               "required": false
             },
             "TVAccessory": {
-              "title": "TV accessory in homekit (Defaults to true if not set)",
-              "type": "boolean"
+              "title": "TV accessory in homekit",
+              "type": "boolean",
+              "default": false
             },
             "sortInput": {
               "title": "sort input list in TV accessory : 0-default,1:Alpha,2:activityOrder property of hub, 3:activitiesToPublishAsInputForTVMode order (defaults to 0).",


### PR DESCRIPTION
... by setting default values for all hubs in config.schema (true for the primary hub, false for any other hub)

This creates a otherPlatform entry with TVAccessory set to false and so it won't be exposed. 

I've change the description slightly and removed the mentioning of the default value. It's a bit weird that a check box is not marked, while the help message says its default is true if not set.