### PR TITLE
Tell homebridge this is v2 comptatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/nicoduj/homebridge-harmony.git"
   },
   "engines": {
-    "homebridge": ">=1.0.4",
+    "homebridge": ">=1.0.4 || ^2.0.0-beta.0 || >=2.0.0",
     "node": ">=10.20.0"
   },
   "keywords": [


### PR DESCRIPTION
Works with Homebridge V2 as far as I can tell, this tells Homebridge to stop showing the warning