### PR TITLE
Retry reconnect after socket close until hub is reachable again

### DIFF
--- a/harmonyBase.js
+++ b/harmonyBase.js
@@ -281,26 +281,46 @@ HarmonyBase.prototype = {
     this.harmony.on('close', () => {
       harmonyPlatform.log('(' + harmonyPlatform.name + ')' + 'WARNING - socket closed');
 
-      setTimeout(() => {
-        if (HarmonyTools.isNil(harmonyPlatform.hubRemoteId)) {
-          this.harmony
-            .connect(harmonyPlatform.hubIP)
-            .then(() => {
-              this.refreshCurrentActivity(harmonyPlatform, () => {});
-            })
-            .catch((e3) => {
-              harmonyPlatform.log(
-                '(' +
-                  harmonyPlatform.name +
-                  ')' +
-                  'Error - Error connecting after socket closed  ' +
-                  e3.message
-              );
-            });
-        } else {
-          harmonyPlatform.mainPlatform.discoverHub();
-        }
-      }, HarmonyConst.DELAY_BEFORE_RECONNECT);
+      // Hub outages outlast DELAY_BEFORE_RECONNECT, so a single connect attempt
+      // always lands while the hub is still down (ECONNREFUSED) and the plugin
+      // then stays disconnected — push notifications stop until something else
+      // reopens the socket. Retry until the hub is reachable again, with a guard
+      // so overlapping 'close' events can't spawn parallel retry loops.
+      if (this.reconnectAttemptsLeft > 0) return;
+      this.reconnectAttemptsLeft = 120;
+
+      const attemptReconnect = () => {
+        setTimeout(() => {
+          if (HarmonyTools.isNil(harmonyPlatform.hubRemoteId)) {
+            this.harmony
+              .connect(harmonyPlatform.hubIP)
+              .then(() => {
+                this.reconnectAttemptsLeft = 0;
+                harmonyPlatform.log(
+                  '(' + harmonyPlatform.name + ')' + 'INFO - reconnected after socket close'
+                );
+                this.refreshCurrentActivity(harmonyPlatform, () => {});
+              })
+              .catch((e3) => {
+                this.reconnectAttemptsLeft = this.reconnectAttemptsLeft - 1;
+                harmonyPlatform.log(
+                  '(' +
+                    harmonyPlatform.name +
+                    ')' +
+                    'Error - Error connecting after socket closed (' +
+                    this.reconnectAttemptsLeft +
+                    ' attempts left) ' +
+                    e3.message
+                );
+                if (this.reconnectAttemptsLeft > 0) attemptReconnect();
+              });
+          } else {
+            this.reconnectAttemptsLeft = 0;
+            harmonyPlatform.mainPlatform.discoverHub();
+          }
+        }, HarmonyConst.DELAY_BEFORE_RECONNECT);
+      };
+      attemptReconnect();
     });
 
     this.harmony.on('automationState', (message) => {


### PR DESCRIPTION
## Problem

Harmony hubs periodically restart their local API (a firmware behavior — observed every ~2.5h on one hub and ~9.3h on another, with outages lasting ~30–65s). After such a restart, the plugin never reconnects: `stateDigest` push notifications stop arriving, so HomeKit automations tied to activity changes silently stop firing.

Confusingly, direct commands (switches, volume, remote keys) keep working, and opening the iOS Home app temporarily "fixes" automations — which makes the issue look random and hard to attribute to the plugin.

## Root cause

In `harmonyBase.js`, the `close` handler makes exactly **one** reconnect attempt, `DELAY_BEFORE_RECONNECT` (5s) after the socket drops. Since hub restarts take 30–65s, that attempt lands while the hub is still down and fails at the HTTP `getRemoteId` step (`ECONNREFUSED`). Because no socket was ever opened, no further `close` event fires, so the reconnect logic is permanently dead from then on.

Captured logs confirm this on every outage:

```
[10:43:41 AM] WARNING - socket closed
[10:43:46 AM] Error - Error connecting after socket closed  request to http://192.168.x.x:8088/ failed, reason: connect ECONNREFUSED
```

...followed by silence, while an independent client (aioharmony) on the same hub reconnects and keeps receiving pushes.

Why commands still work: every command method in `harmony-websocket` starts with `this._client.open()`, which silently reopens the closed socket on demand. That's also why opening the Home app (which triggers a state read) resurrects pushes.

## Fix

In the `close` handler (fixed-`hubIP` path), retry `connect()` every `DELAY_BEFORE_RECONNECT` until it succeeds, capped at 120 attempts (~10 minutes), with a guard flag so duplicate `close` events can't spawn parallel retry loops. On success, log `INFO - reconnected after socket close` so recovery is visible in the log instead of silent.

A typical hub restart now costs ~6–13 quiet retries and ends with a clean reconnect and working push notifications.

Note: the auto-discovery paths (`updateHub()` and the `discoverHub()` branch) share the same single-attempt pattern and would benefit from the same treatment; this PR only changes the fixed-IP path, which is what I could test.

## Testing

Running on my production install (v2.0.2, two hubs, child bridge process), where the failure was reproduced and logged against every natural hub restart cycle before the patch.